### PR TITLE
feat: Support ffmpeg path via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ run()
 
 ## API
 
-#### genThumbnail(input, output, size)
+#### genThumbnail(input, output, size, [config])
 
 Returns of a `Promise` which resolves on thumbnail creation.
 
@@ -68,3 +68,15 @@ The dimensions of the generated thumbnail. The `size` argument may have one of t
 * `150x?`: set a fixed width and compute the height automatically.
 * `?x100`: set a fixed height and compute the width automatically.
 * `50%`: rescale both width and height to given percentage.
+
+#### config
+
+Type: `Object`
+
+A configuration object, see details below.
+
+#### config.path
+
+Type: `String`
+
+The path of the `ffmpeg` binary. If omitted, the path will be set to the `FFMPEG_PATH` environment variable. If the environment variable is not set, `ffmpeg` will be invoked directly (ie. `ffmpeg [...]`).

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function ffmpegExecute (path, args, stream = null) {
 }
 
 function genThumbnail (input, output, size, config = {}) {
-  const ffmpegPath = config.path || 'ffmpeg'
+  const ffmpegPath = config.path || process.env.FFMPEG_PATH || 'ffmpeg'
 
   const parsedSize = parseSize(size)
   const args = buildArgs(

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/ScottyFillups/simple-thumbnail.git"
   },
   "devDependencies": {
+    "array-flatten": "^2.1.1",
     "chai": "^4.1.2",
     "coveralls": "^3.0.2",
     "dirty-chai": "^2.0.1",

--- a/test/test.js
+++ b/test/test.js
@@ -150,7 +150,7 @@ describe('simple-thumbnail creates thumbnails for videos', () => {
           await genThumbnail(
             filePath,
             absolutePath(`./out/sizes/size-${size.replace('%', '')}.png`),
-            size
+            size,
           )
         } catch (err) {
           console.log(err)
@@ -159,6 +159,10 @@ describe('simple-thumbnail creates thumbnails for videos', () => {
         }
       })
     })
+  })
+
+  describe('alternative ffmpeg paths', () => {
+    it('operates correctly when path specified...'
   })
 
   describe('thumbnail output image formats', () => {


### PR DESCRIPTION
<!--
  While filling all of these sections out is optional, it's highly recommended
  that you fill out context and objective; it doesn't need to be extremely detailed
-->

## Context

Users should be able to specify the path of the `ffmpeg` binary.

## Objective

* Check if `process.env.FFMPEG_PATH` is set; use it if `config.path` is not defined

## Lessons learned

* Setting `process.env.FOOBAR = null` does not "clear" the environment variable; set it to `''`