### PR TITLE
feat(28): Add write-stream output support

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,15 @@
         "doc",
         "code"
       ]
+    },
+    {
+      "login": "cmd430",
+      "name": "cmd430",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/2668906?v=4",
+      "profile": "https://github.com/cmd430",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -15,7 +15,8 @@
       "avatar_url": "https://avatars2.githubusercontent.com/u/18666879?v=4",
       "profile": "http://scottyfillups.io",
       "contributions": [
-        "doc"
+        "doc",
+        "code"
       ]
     }
   ]

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -16,7 +16,8 @@
       "profile": "http://scottyfillups.io",
       "contributions": [
         "doc",
-        "code"
+        "code",
+        "design"
       ]
     },
     {
@@ -25,7 +26,8 @@
       "avatar_url": "https://avatars1.githubusercontent.com/u/2668906?v=4",
       "profile": "https://github.com/cmd430",
       "contributions": [
-        "code"
+        "code",
+        "ideas"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # simple-thumbnail 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
 [![npm version](https://badge.fury.io/js/simple-thumbnail.svg)](https://badge.fury.io/js/simple-thumbnail)
 [![Build Status](https://travis-ci.org/ScottyFillups/simple-thumbnail.svg?branch=master)](https://travis-ci.org/ScottyFillups/simple-thumbnail)
 [![Coverage Status](https://coveralls.io/repos/github/ScottyFillups/simple-thumbnail/badge.svg?branch=master)](https://coveralls.io/github/ScottyFillups/simple-thumbnail?branch=master)
@@ -106,8 +106,8 @@ Seeks the video to the provided time. The time must be in the following form: `h
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars2.githubusercontent.com/u/18666879?v=4" width="100px;"/><br /><sub><b>Philip Scott</b></sub>](http://scottyfillups.io)<br />[📖](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Documentation") [💻](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Code") |
-| :---: |
+| [<img src="https://avatars2.githubusercontent.com/u/18666879?v=4" width="100px;"/><br /><sub><b>Philip Scott</b></sub>](http://scottyfillups.io)<br />[📖](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Documentation") [💻](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Code") | [<img src="https://avatars1.githubusercontent.com/u/2668906?v=4" width="100px;"/><br /><sub><b>cmd430</b></sub>](https://github.com/cmd430)<br />[💻](https://github.com/ScottyFillups/simple-thumbnail/commits?author=cmd430 "Code") |
+| :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 <!-- ALL-CONTRIBUTORS-LIST: START - Do not remove or modify this section -->
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -111,3 +111,7 @@ Seeks the video to the provided time. The time must be in the following form: `h
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 <!-- ALL-CONTRIBUTORS-LIST: START - Do not remove or modify this section -->
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.
+
+Contributions of any kind are welcome!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # simple-thumbnail 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=rounded)](#contributors)
 [![npm version](https://badge.fury.io/js/simple-thumbnail.svg)](https://badge.fury.io/js/simple-thumbnail)
 [![Build Status](https://travis-ci.org/ScottyFillups/simple-thumbnail.svg?branch=master)](https://travis-ci.org/ScottyFillups/simple-thumbnail)
 [![Coverage Status](https://coveralls.io/repos/github/ScottyFillups/simple-thumbnail/badge.svg?branch=master)](https://coveralls.io/github/ScottyFillups/simple-thumbnail?branch=master)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ async function run () {
 }
 
 run()
+
+// genThumbnail also supports piping to write streams, so you can do this with Express!
+app.get('/some/endpoint', (req, res) => {
+  genThumbnail('path/to/video.webm', res, '150x100')
+    .then(() => console.log('done!'))
+    .catch(err => console.error(err))
+})
 ```
 
 ## Getting FFmpeg

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Seeks the video to the provided time. The time must be in the following form: `h
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars2.githubusercontent.com/u/18666879?v=4" width="100px;"/><br /><sub><b>Philip Scott</b></sub>](http://scottyfillups.io)<br />[📖](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Documentation") [💻](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Code") | [<img src="https://avatars1.githubusercontent.com/u/2668906?v=4" width="100px;"/><br /><sub><b>cmd430</b></sub>](https://github.com/cmd430)<br />[💻](https://github.com/ScottyFillups/simple-thumbnail/commits?author=cmd430 "Code") |
+| [<img src="https://avatars2.githubusercontent.com/u/18666879?v=4" width="100px;"/><br /><sub><b>Philip Scott</b></sub>](http://scottyfillups.io)<br />[📖](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Documentation") [💻](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Code") [🎨](#design-ScottyFillups "Design") | [<img src="https://avatars1.githubusercontent.com/u/2668906?v=4" width="100px;"/><br /><sub><b>cmd430</b></sub>](https://github.com/cmd430)<br />[💻](https://github.com/ScottyFillups/simple-thumbnail/commits?author=cmd430 "Code") [🤔](#ideas-cmd430 "Ideas, Planning, & Feedback") |
 | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 <!-- ALL-CONTRIBUTORS-LIST: START - Do not remove or modify this section -->

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ The URL, file path, or read-stream of an image or video.
 
 #### output
 
-Type: `String | stream.Writable`
+Type: `String | stream.Writable | Null`
 
-The file path of the generated thumbnail or a write-stream. If you're specifying a file path, make sure the directories exist.
+The file path of the generated thumbnail, a write-stream, or null. If null, `genThumbnail` will resolve to a read-stream that you can pipe somewhere. If you're specifying a file path, make sure the directories exist.
 
 #### size
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # simple-thumbnail 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=rounded)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
 [![npm version](https://badge.fury.io/js/simple-thumbnail.svg)](https://badge.fury.io/js/simple-thumbnail)
 [![Build Status](https://travis-ci.org/ScottyFillups/simple-thumbnail.svg?branch=master)](https://travis-ci.org/ScottyFillups/simple-thumbnail)
 [![Coverage Status](https://coveralls.io/repos/github/ScottyFillups/simple-thumbnail/badge.svg?branch=master)](https://coveralls.io/github/ScottyFillups/simple-thumbnail?branch=master)
@@ -69,9 +69,9 @@ The URL, file path, or read-stream of an image or video.
 
 #### output
 
-Type: `String`
+Type: `String | stream.Writable`
 
-The file path of the generated thumbnail, assumes directories exist.
+The file path of the generated thumbnail or a write-stream. If you're specifying a file path, make sure the directories exist.
 
 #### size
 
@@ -106,7 +106,7 @@ Seeks the video to the provided time. The time must be in the following form: `h
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars2.githubusercontent.com/u/18666879?v=4" width="100px;"/><br /><sub><b>Philip Scott</b></sub>](http://scottyfillups.io)<br />[📖](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Documentation") |
+| [<img src="https://avatars2.githubusercontent.com/u/18666879?v=4" width="100px;"/><br /><sub><b>Philip Scott</b></sub>](http://scottyfillups.io)<br />[📖](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Documentation") [💻](https://github.com/ScottyFillups/simple-thumbnail/commits?author=ScottyFillups "Code") |
 | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 <!-- ALL-CONTRIBUTORS-LIST: START - Do not remove or modify this section -->

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ function genThumbnail (input, output, size, config = {}) {
     seek
   )
 
-  if (output === null) {
+  if (!output) {
     return ffmpegStreamExecute(ffmpegPath, args, rstream)
   }
 

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ function genThumbnail (input, output, size, config = {}) {
     seek
   )
 
-  if (!output) {
+  if (output === null) {
     return ffmpegStreamExecute(ffmpegPath, args, rstream)
   }
 

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -9,10 +9,10 @@ devDependencies:
   mocha: 5.2.0
   nock: 9.6.1
   nyc: 12.0.2
-  semantic-release: 15.9.16
+  semantic-release: 15.12.4
   sinon: 6.3.4
   standard: 12.0.1
-  travis-deploy-once: 5.0.8
+  travis-deploy-once: 5.0.9
 packages:
   /@babel/code-frame/7.0.0:
     dependencies:
@@ -26,37 +26,27 @@ packages:
     dev: true
     resolution:
       integrity: sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=
-  /@babel/core/7.1.0:
+  /@babel/core/7.2.0:
     dependencies:
       '@babel/code-frame': 7.0.0
-      '@babel/generator': 7.0.0
-      '@babel/helpers': 7.1.0
-      '@babel/parser': 7.1.0
-      '@babel/template': 7.1.0
-      '@babel/traverse': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/generator': 7.2.0
+      '@babel/helpers': 7.2.0
+      '@babel/parser': 7.2.0
+      '@babel/template': 7.1.2
+      '@babel/traverse': 7.1.6
+      '@babel/types': 7.2.0
       convert-source-map: 1.6.0
-      debug: 3.2.5
-      json5: 0.5.1
+      debug: 4.1.0
+      json5: 2.1.0
       lodash: 4.17.11
       resolve: 1.8.1
-      semver: 5.5.1
+      semver: 5.6.0
       source-map: 0.5.7
     dev: true
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-9EWmD0cQAbcXSc+31RIoYgEHx3KQ2CCSMDBhnXrShWvo45TMw+3/55KVxlhkG53kw9tl87DqINgHDgFVhZJV/Q==
-  /@babel/generator/7.0.0:
-    dependencies:
-      '@babel/types': 7.0.0
-      jsesc: 2.5.1
-      lodash: 4.17.11
-      source-map: 0.5.7
-      trim-right: 1.0.1
-    dev: true
-    resolution:
-      integrity: sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==
+      integrity: sha512-7pvAdC4B+iKjFFp9Ztj0QgBndJ++qaMeonT185wAqUnhipw8idm9Rv1UMyBuKtYjfl6ORNkgEgcsYLfHX/GpLw==
   /@babel/generator/7.0.0-beta.51:
     dependencies:
       '@babel/types': 7.0.0-beta.51
@@ -67,39 +57,49 @@ packages:
     dev: true
     resolution:
       integrity: sha1-bHV1/952HQdIXgS67cA5LG2eMPY=
+  /@babel/generator/7.2.0:
+    dependencies:
+      '@babel/types': 7.2.0
+      jsesc: 2.5.2
+      lodash: 4.17.11
+      source-map: 0.5.7
+      trim-right: 1.0.1
+    dev: true
+    resolution:
+      integrity: sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==
   /@babel/helper-annotate-as-pure/7.0.0:
     dependencies:
-      '@babel/types': 7.0.0
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==
   /@babel/helper-builder-binary-assignment-operator-visitor/7.1.0:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==
   /@babel/helper-call-delegate/7.1.0:
     dependencies:
       '@babel/helper-hoist-variables': 7.0.0
-      '@babel/traverse': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/traverse': 7.1.6
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==
   /@babel/helper-define-map/7.1.0:
     dependencies:
       '@babel/helper-function-name': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/types': 7.2.0
       lodash: 4.17.11
     dev: true
     resolution:
       integrity: sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==
   /@babel/helper-explode-assignable-expression/7.1.0:
     dependencies:
-      '@babel/traverse': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/traverse': 7.1.6
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==
@@ -114,14 +114,14 @@ packages:
   /@babel/helper-function-name/7.1.0:
     dependencies:
       '@babel/helper-get-function-arity': 7.0.0
-      '@babel/template': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/template': 7.1.2
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
   /@babel/helper-get-function-arity/7.0.0:
     dependencies:
-      '@babel/types': 7.0.0
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
@@ -133,19 +133,19 @@ packages:
       integrity: sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=
   /@babel/helper-hoist-variables/7.0.0:
     dependencies:
-      '@babel/types': 7.0.0
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==
   /@babel/helper-member-expression-to-functions/7.0.0:
     dependencies:
-      '@babel/types': 7.0.0
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==
   /@babel/helper-module-imports/7.0.0:
     dependencies:
-      '@babel/types': 7.0.0
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
@@ -154,15 +154,15 @@ packages:
       '@babel/helper-module-imports': 7.0.0
       '@babel/helper-simple-access': 7.1.0
       '@babel/helper-split-export-declaration': 7.0.0
-      '@babel/template': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/template': 7.1.2
+      '@babel/types': 7.2.0
       lodash: 4.17.11
     dev: true
     resolution:
       integrity: sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==
   /@babel/helper-optimise-call-expression/7.0.0:
     dependencies:
-      '@babel/types': 7.0.0
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==
@@ -179,10 +179,10 @@ packages:
   /@babel/helper-remap-async-to-generator/7.1.0:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.0.0
-      '@babel/helper-wrap-function': 7.1.0
-      '@babel/template': 7.1.0
-      '@babel/traverse': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/helper-wrap-function': 7.2.0
+      '@babel/template': 7.1.2
+      '@babel/traverse': 7.1.6
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==
@@ -190,21 +190,21 @@ packages:
     dependencies:
       '@babel/helper-member-expression-to-functions': 7.0.0
       '@babel/helper-optimise-call-expression': 7.0.0
-      '@babel/traverse': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/traverse': 7.1.6
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==
   /@babel/helper-simple-access/7.1.0:
     dependencies:
-      '@babel/template': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/template': 7.1.2
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==
   /@babel/helper-split-export-declaration/7.0.0:
     dependencies:
-      '@babel/types': 7.0.0
+      '@babel/types': 7.2.0
     dev: true
     resolution:
       integrity: sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==
@@ -214,23 +214,23 @@ packages:
     dev: true
     resolution:
       integrity: sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=
-  /@babel/helper-wrap-function/7.1.0:
+  /@babel/helper-wrap-function/7.2.0:
     dependencies:
       '@babel/helper-function-name': 7.1.0
-      '@babel/template': 7.1.0
-      '@babel/traverse': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/template': 7.1.2
+      '@babel/traverse': 7.1.6
+      '@babel/types': 7.2.0
     dev: true
     resolution:
-      integrity: sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==
-  /@babel/helpers/7.1.0:
+      integrity: sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==
+  /@babel/helpers/7.2.0:
     dependencies:
-      '@babel/template': 7.1.0
-      '@babel/traverse': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/template': 7.1.2
+      '@babel/traverse': 7.1.6
+      '@babel/types': 7.2.0
     dev: true
     resolution:
-      integrity: sha512-V1jXUTNdTpBn37wqqN73U+eBpzlLHmxA4aDaghJBggmzly/FpIJMHXse9lgdzQQT4gs5jZ5NmYxOL8G3ROc29g==
+      integrity: sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==
   /@babel/highlight/7.0.0:
     dependencies:
       chalk: 2.4.1
@@ -254,158 +254,158 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=
-  /@babel/parser/7.1.0:
+  /@babel/parser/7.2.0:
     dev: true
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==
-  /@babel/plugin-proposal-async-generator-functions/7.1.0/@babel!core@7.1.0:
+      integrity: sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==
+  /@babel/plugin-proposal-async-generator-functions/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-remap-async-to-generator': 7.1.0
-      '@babel/plugin-syntax-async-generators': /@babel/plugin-syntax-async-generators/7.0.0/@babel!core@7.1.0
+      '@babel/plugin-syntax-async-generators': /@babel/plugin-syntax-async-generators/7.2.0/@babel!core@7.2.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/7.1.0
+    id: registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==
-  /@babel/plugin-proposal-json-strings/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==
+  /@babel/plugin-proposal-json-strings/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-json-strings': /@babel/plugin-syntax-json-strings/7.0.0/@babel!core@7.1.0
+      '@babel/plugin-syntax-json-strings': /@babel/plugin-syntax-json-strings/7.2.0/@babel!core@7.2.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-proposal-json-strings/7.0.0
+    id: registry.npmjs.org/@babel/plugin-proposal-json-strings/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==
-  /@babel/plugin-proposal-object-rest-spread/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==
+  /@babel/plugin-proposal-object-rest-spread/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.0.0/@babel!core@7.1.0
+      '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.2.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/7.0.0
+    id: registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==
-  /@babel/plugin-proposal-optional-catch-binding/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-1L5mWLSvR76XYUQJXkd/EEQgjq8HHRP6lQuZTTg0VA4tTGPpGemmCdAfQIz1rzEuWAm+ecP8PyyEm30jC1eQCg==
+  /@babel/plugin-proposal-optional-catch-binding/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-optional-catch-binding': /@babel/plugin-syntax-optional-catch-binding/7.0.0/@babel!core@7.1.0
+      '@babel/plugin-syntax-optional-catch-binding': /@babel/plugin-syntax-optional-catch-binding/7.2.0/@babel!core@7.2.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/7.0.0
+    id: registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==
-  /@babel/plugin-proposal-unicode-property-regex/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==
+  /@babel/plugin-proposal-unicode-property-regex/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-regex': 7.0.0
       regexpu-core: 4.2.0
     dev: true
     engines:
       node: '>=4'
-    id: registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/7.0.0
+    id: registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==
-  /@babel/plugin-syntax-async-generators/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==
+  /@babel/plugin-syntax-async-generators/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-syntax-async-generators/7.0.0
+    id: registry.npmjs.org/@babel/plugin-syntax-async-generators/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==
-  /@babel/plugin-syntax-json-strings/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
+  /@babel/plugin-syntax-json-strings/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-syntax-json-strings/7.0.0
+    id: registry.npmjs.org/@babel/plugin-syntax-json-strings/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==
-  /@babel/plugin-syntax-object-rest-spread/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==
+  /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/7.0.0
+    id: registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==
-  /@babel/plugin-syntax-optional-catch-binding/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
+  /@babel/plugin-syntax-optional-catch-binding/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/7.0.0
+    id: registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==
-  /@babel/plugin-transform-arrow-functions/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
+  /@babel/plugin-transform-arrow-functions/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-arrow-functions/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-arrow-functions/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==
-  /@babel/plugin-transform-async-to-generator/7.1.0/@babel!core@7.1.0:
+      integrity: sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==
+  /@babel/plugin-transform-async-to-generator/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-module-imports': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-remap-async-to-generator': 7.1.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-async-to-generator/7.1.0
+    id: registry.npmjs.org/@babel/plugin-transform-async-to-generator/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==
-  /@babel/plugin-transform-block-scoped-functions/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==
+  /@babel/plugin-transform-block-scoped-functions/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==
-  /@babel/plugin-transform-block-scoping/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==
+  /@babel/plugin-transform-block-scoping/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
       lodash: 4.17.11
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-block-scoping/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-block-scoping/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==
-  /@babel/plugin-transform-classes/7.1.0/@babel!core@7.1.0:
+      integrity: sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==
+  /@babel/plugin-transform-classes/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-annotate-as-pure': 7.0.0
       '@babel/helper-define-map': 7.1.0
       '@babel/helper-function-name': 7.1.0
@@ -413,147 +413,147 @@ packages:
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-replace-supers': 7.1.0
       '@babel/helper-split-export-declaration': 7.0.0
-      globals: 11.7.0
+      globals: 11.9.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-classes/7.1.0
+    id: registry.npmjs.org/@babel/plugin-transform-classes/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==
-  /@babel/plugin-transform-computed-properties/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-aPCEkrhJYebDXcGTAP+cdUENkH7zqOlgbKwLbghjjHpJRJBWM/FSlCjMoPGA8oUdiMfOrk3+8EFPLLb5r7zj2w==
+  /@babel/plugin-transform-computed-properties/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-computed-properties/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-computed-properties/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==
-  /@babel/plugin-transform-destructuring/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==
+  /@babel/plugin-transform-destructuring/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-destructuring/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-destructuring/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==
-  /@babel/plugin-transform-dotall-regex/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-coVO2Ayv7g0qdDbrNiadE4bU7lvCd9H539m2gMknyVjjMdwF/iCOM7R+E8PkntoqLkltO0rk+3axhpp/0v68VQ==
+  /@babel/plugin-transform-dotall-regex/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-regex': 7.0.0
       regexpu-core: 4.2.0
     dev: true
     engines:
       node: '>=4'
-    id: registry.npmjs.org/@babel/plugin-transform-dotall-regex/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-dotall-regex/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==
-  /@babel/plugin-transform-duplicate-keys/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==
+  /@babel/plugin-transform-duplicate-keys/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-duplicate-keys/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-duplicate-keys/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==
-  /@babel/plugin-transform-exponentiation-operator/7.1.0/@babel!core@7.1.0:
+      integrity: sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==
+  /@babel/plugin-transform-exponentiation-operator/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.1.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/7.1.0
+    id: registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==
-  /@babel/plugin-transform-for-of/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==
+  /@babel/plugin-transform-for-of/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-for-of/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-for-of/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==
-  /@babel/plugin-transform-function-name/7.1.0/@babel!core@7.1.0:
+      integrity: sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==
+  /@babel/plugin-transform-function-name/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-function-name': 7.1.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-function-name/7.1.0
+    id: registry.npmjs.org/@babel/plugin-transform-function-name/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==
-  /@babel/plugin-transform-literals/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==
+  /@babel/plugin-transform-literals/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-literals/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-literals/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==
-  /@babel/plugin-transform-modules-amd/7.1.0/@babel!core@7.1.0:
+      integrity: sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==
+  /@babel/plugin-transform-modules-amd/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-module-transforms': 7.1.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-modules-amd/7.1.0
+    id: registry.npmjs.org/@babel/plugin-transform-modules-amd/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==
-  /@babel/plugin-transform-modules-commonjs/7.1.0/@babel!core@7.1.0:
+      integrity: sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==
+  /@babel/plugin-transform-modules-commonjs/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-module-transforms': 7.1.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-simple-access': 7.1.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-modules-commonjs/7.1.0
+    id: registry.npmjs.org/@babel/plugin-transform-modules-commonjs/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==
-  /@babel/plugin-transform-modules-systemjs/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==
+  /@babel/plugin-transform-modules-systemjs/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-hoist-variables': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-modules-systemjs/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-modules-systemjs/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-8EDKMAsitLkiF/D4Zhe9CHEE2XLh4bfLbb9/Zf3FgXYQOZyZYyg7EAel/aT2A7bHv62jwHf09q2KU/oEexr83g==
-  /@babel/plugin-transform-modules-umd/7.1.0/@babel!core@7.1.0:
+      integrity: sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==
+  /@babel/plugin-transform-modules-umd/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-module-transforms': 7.1.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-modules-umd/7.1.0
+    id: registry.npmjs.org/@babel/plugin-transform-modules-umd/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==
-  /@babel/plugin-transform-new-target/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==
+  /@babel/plugin-transform-new-target/7.0.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     id: registry.npmjs.org/@babel/plugin-transform-new-target/7.0.0
@@ -561,32 +561,32 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==
-  /@babel/plugin-transform-object-super/7.1.0/@babel!core@7.1.0:
+  /@babel/plugin-transform-object-super/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-replace-supers': 7.1.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-object-super/7.1.0
+    id: registry.npmjs.org/@babel/plugin-transform-object-super/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==
-  /@babel/plugin-transform-parameters/7.1.0/@babel!core@7.1.0:
+      integrity: sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==
+  /@babel/plugin-transform-parameters/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-call-delegate': 7.1.0
       '@babel/helper-get-function-arity': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-parameters/7.1.0
+    id: registry.npmjs.org/@babel/plugin-transform-parameters/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==
-  /@babel/plugin-transform-regenerator/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==
+  /@babel/plugin-transform-regenerator/7.0.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       regenerator-transform: 0.13.3
     dev: true
     id: registry.npmjs.org/@babel/plugin-transform-regenerator/7.0.0
@@ -594,70 +594,70 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==
-  /@babel/plugin-transform-shorthand-properties/7.0.0/@babel!core@7.1.0:
+  /@babel/plugin-transform-shorthand-properties/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-shorthand-properties/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-shorthand-properties/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==
-  /@babel/plugin-transform-spread/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==
+  /@babel/plugin-transform-spread/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-spread/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-spread/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==
-  /@babel/plugin-transform-sticky-regex/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-7TtPIdwjS/i5ZBlNiQePQCovDh9pAhVbp/nGVRBZuUdBiVRThyyLend3OHobc0G+RLCPPAN70+z/MAMhsgJd/A==
+  /@babel/plugin-transform-sticky-regex/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-regex': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-sticky-regex/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-sticky-regex/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==
-  /@babel/plugin-transform-template-literals/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==
+  /@babel/plugin-transform-template-literals/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-annotate-as-pure': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-template-literals/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-template-literals/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==
-  /@babel/plugin-transform-typeof-symbol/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==
+  /@babel/plugin-transform-typeof-symbol/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-typeof-symbol/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-typeof-symbol/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==
-  /@babel/plugin-transform-unicode-regex/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==
+  /@babel/plugin-transform-unicode-regex/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-regex': 7.0.0
       regexpu-core: 4.2.0
     dev: true
-    id: registry.npmjs.org/@babel/plugin-transform-unicode-regex/7.0.0
+    id: registry.npmjs.org/@babel/plugin-transform-unicode-regex/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==
+      integrity: sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==
   /@babel/polyfill/7.0.0:
     dependencies:
       core-js: 2.5.7
@@ -665,59 +665,59 @@ packages:
     dev: true
     resolution:
       integrity: sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==
-  /@babel/preset-env/7.1.0/@babel!core@7.1.0:
+  /@babel/preset-env/7.2.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/helper-module-imports': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-proposal-async-generator-functions': /@babel/plugin-proposal-async-generator-functions/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-proposal-json-strings': /@babel/plugin-proposal-json-strings/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-proposal-object-rest-spread': /@babel/plugin-proposal-object-rest-spread/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-proposal-optional-catch-binding': /@babel/plugin-proposal-optional-catch-binding/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-proposal-unicode-property-regex': /@babel/plugin-proposal-unicode-property-regex/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-syntax-async-generators': /@babel/plugin-syntax-async-generators/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-syntax-optional-catch-binding': /@babel/plugin-syntax-optional-catch-binding/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-arrow-functions': /@babel/plugin-transform-arrow-functions/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-async-to-generator': /@babel/plugin-transform-async-to-generator/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-transform-block-scoped-functions': /@babel/plugin-transform-block-scoped-functions/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-block-scoping': /@babel/plugin-transform-block-scoping/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-classes': /@babel/plugin-transform-classes/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-transform-computed-properties': /@babel/plugin-transform-computed-properties/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-destructuring': /@babel/plugin-transform-destructuring/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-dotall-regex': /@babel/plugin-transform-dotall-regex/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-duplicate-keys': /@babel/plugin-transform-duplicate-keys/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-exponentiation-operator': /@babel/plugin-transform-exponentiation-operator/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-transform-for-of': /@babel/plugin-transform-for-of/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-function-name': /@babel/plugin-transform-function-name/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-transform-literals': /@babel/plugin-transform-literals/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-modules-amd': /@babel/plugin-transform-modules-amd/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-transform-modules-commonjs': /@babel/plugin-transform-modules-commonjs/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-transform-modules-systemjs': /@babel/plugin-transform-modules-systemjs/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-modules-umd': /@babel/plugin-transform-modules-umd/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-transform-new-target': /@babel/plugin-transform-new-target/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-object-super': /@babel/plugin-transform-object-super/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-transform-parameters': /@babel/plugin-transform-parameters/7.1.0/@babel!core@7.1.0
-      '@babel/plugin-transform-regenerator': /@babel/plugin-transform-regenerator/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-shorthand-properties': /@babel/plugin-transform-shorthand-properties/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-spread': /@babel/plugin-transform-spread/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-sticky-regex': /@babel/plugin-transform-sticky-regex/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-template-literals': /@babel/plugin-transform-template-literals/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-typeof-symbol': /@babel/plugin-transform-typeof-symbol/7.0.0/@babel!core@7.1.0
-      '@babel/plugin-transform-unicode-regex': /@babel/plugin-transform-unicode-regex/7.0.0/@babel!core@7.1.0
-      browserslist: 4.1.1
+      '@babel/plugin-proposal-async-generator-functions': /@babel/plugin-proposal-async-generator-functions/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-proposal-json-strings': /@babel/plugin-proposal-json-strings/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-proposal-object-rest-spread': /@babel/plugin-proposal-object-rest-spread/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-proposal-optional-catch-binding': /@babel/plugin-proposal-optional-catch-binding/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-proposal-unicode-property-regex': /@babel/plugin-proposal-unicode-property-regex/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-syntax-async-generators': /@babel/plugin-syntax-async-generators/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-syntax-optional-catch-binding': /@babel/plugin-syntax-optional-catch-binding/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-arrow-functions': /@babel/plugin-transform-arrow-functions/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-async-to-generator': /@babel/plugin-transform-async-to-generator/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-block-scoped-functions': /@babel/plugin-transform-block-scoped-functions/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-block-scoping': /@babel/plugin-transform-block-scoping/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-classes': /@babel/plugin-transform-classes/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-computed-properties': /@babel/plugin-transform-computed-properties/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-destructuring': /@babel/plugin-transform-destructuring/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-dotall-regex': /@babel/plugin-transform-dotall-regex/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-duplicate-keys': /@babel/plugin-transform-duplicate-keys/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-exponentiation-operator': /@babel/plugin-transform-exponentiation-operator/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-for-of': /@babel/plugin-transform-for-of/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-function-name': /@babel/plugin-transform-function-name/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-literals': /@babel/plugin-transform-literals/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-modules-amd': /@babel/plugin-transform-modules-amd/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-modules-commonjs': /@babel/plugin-transform-modules-commonjs/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-modules-systemjs': /@babel/plugin-transform-modules-systemjs/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-modules-umd': /@babel/plugin-transform-modules-umd/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-new-target': /@babel/plugin-transform-new-target/7.0.0/@babel!core@7.2.0
+      '@babel/plugin-transform-object-super': /@babel/plugin-transform-object-super/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-parameters': /@babel/plugin-transform-parameters/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-regenerator': /@babel/plugin-transform-regenerator/7.0.0/@babel!core@7.2.0
+      '@babel/plugin-transform-shorthand-properties': /@babel/plugin-transform-shorthand-properties/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-spread': /@babel/plugin-transform-spread/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-sticky-regex': /@babel/plugin-transform-sticky-regex/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-template-literals': /@babel/plugin-transform-template-literals/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-typeof-symbol': /@babel/plugin-transform-typeof-symbol/7.2.0/@babel!core@7.2.0
+      '@babel/plugin-transform-unicode-regex': /@babel/plugin-transform-unicode-regex/7.2.0/@babel!core@7.2.0
+      browserslist: 4.3.5
       invariant: 2.2.4
-      js-levenshtein: 1.1.3
-      semver: 5.5.1
+      js-levenshtein: 1.1.4
+      semver: 5.6.0
     dev: true
-    id: registry.npmjs.org/@babel/preset-env/7.1.0
+    id: registry.npmjs.org/@babel/preset-env/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==
-  /@babel/register/7.0.0/@babel!core@7.1.0:
+      integrity: sha512-haGR38j5vOGVeBatrQPr3l0xHbs14505DcM57cbJy48kgMFvvHHoYEhHuRV+7vi559yyAUAVbTWzbK/B/pzJng==
+  /@babel/register/7.0.0/@babel!core@7.2.0:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       core-js: 2.5.7
       find-cache-dir: 1.0.0
       home-or-tmp: 3.0.0
@@ -740,14 +740,14 @@ packages:
     dev: true
     resolution:
       integrity: sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=
-  /@babel/template/7.1.0:
+  /@babel/template/7.1.2:
     dependencies:
       '@babel/code-frame': 7.0.0
-      '@babel/parser': 7.1.0
-      '@babel/types': 7.0.0
+      '@babel/parser': 7.2.0
+      '@babel/types': 7.2.0
     dev: true
     resolution:
-      integrity: sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==
+      integrity: sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==
   /@babel/traverse/7.0.0-beta.51:
     dependencies:
       '@babel/code-frame': 7.0.0-beta.51
@@ -763,28 +763,20 @@ packages:
     dev: true
     resolution:
       integrity: sha1-mB2vLOw0emIx06odnhgDsDqqpKg=
-  /@babel/traverse/7.1.0:
+  /@babel/traverse/7.1.6:
     dependencies:
       '@babel/code-frame': 7.0.0
-      '@babel/generator': 7.0.0
+      '@babel/generator': 7.2.0
       '@babel/helper-function-name': 7.1.0
       '@babel/helper-split-export-declaration': 7.0.0
-      '@babel/parser': 7.1.0
-      '@babel/types': 7.0.0
-      debug: 3.2.5
-      globals: 11.7.0
+      '@babel/parser': 7.2.0
+      '@babel/types': 7.2.0
+      debug: 4.1.0
+      globals: 11.9.0
       lodash: 4.17.11
     dev: true
     resolution:
-      integrity: sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==
-  /@babel/types/7.0.0:
-    dependencies:
-      esutils: 2.0.2
-      lodash: 4.17.11
-      to-fast-properties: 2.0.0
-    dev: true
-    resolution:
-      integrity: sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==
+      integrity: sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==
   /@babel/types/7.0.0-beta.51:
     dependencies:
       esutils: 2.0.2
@@ -793,6 +785,14 @@ packages:
     dev: true
     resolution:
       integrity: sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=
+  /@babel/types/7.2.0:
+    dependencies:
+      esutils: 2.0.2
+      lodash: 4.17.11
+      to-fast-properties: 2.0.0
+    dev: true
+    resolution:
+      integrity: sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==
   /@mrmlnc/readdir-enhanced/2.2.1:
     dependencies:
       call-me-maybe: 1.0.1
@@ -802,34 +802,51 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==
-  /@nodelib/fs.stat/1.1.2:
+  /@nodelib/fs.stat/1.1.3:
     dev: true
     engines:
       node: '>= 6'
     resolution:
-      integrity: sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==
-  /@octokit/rest/15.12.0:
+      integrity: sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+  /@octokit/endpoint/3.1.1:
     dependencies:
-      before-after-hook: 1.1.0
-      btoa-lite: 1.0.0
-      debug: 3.2.5
-      http-proxy-agent: 2.1.0
-      https-proxy-agent: 2.2.1
-      lodash: 4.17.11
-      node-fetch: 2.2.0
-      universal-user-agent: 2.0.1
+      deepmerge: 3.0.0
+      is-plain-object: 2.0.4
+      universal-user-agent: 2.0.2
       url-template: 2.0.8
     dev: true
-    engines:
-      node: '>=4'
     resolution:
-      integrity: sha512-5wRag4kHRkp0JDo++L9x9FkDlHEALbLnbSede16D8u+a2/t+gX32uhDs8cukVLyyrZR79nmh1lNpxZmffwoNoQ==
-  /@semantic-release/commit-analyzer/6.0.1:
+      integrity: sha512-KPkoTvKwCTetu/UqonLs1pfwFO5HAqTv/Ksp9y4NAg//ZgUCpvJsT4Hrst85uEzJvkB8+LxKyR4Bfv2X8O4cmQ==
+  /@octokit/request/2.2.0:
     dependencies:
-      conventional-changelog-angular: 5.0.1
-      conventional-commits-filter: 2.0.0
-      conventional-commits-parser: 3.0.0
-      debug: 4.0.1
+      '@octokit/endpoint': 3.1.1
+      is-plain-object: 2.0.4
+      node-fetch: 2.3.0
+      universal-user-agent: 2.0.2
+    dev: true
+    resolution:
+      integrity: sha512-4P9EbwKZ4xfyupVMb3KVuHmM+aO2fye3nufjGKz/qDssvdJj9Rlx44O0FdFvUp4kIzToy3AHLTOulEIDAL+dpg==
+  /@octokit/rest/16.1.0:
+    dependencies:
+      '@octokit/request': 2.2.0
+      before-after-hook: 1.2.0
+      btoa-lite: 1.0.0
+      lodash.get: 4.4.2
+      lodash.pick: 4.4.0
+      lodash.set: 4.3.2
+      lodash.uniq: 4.5.0
+      octokit-pagination-methods: 1.1.0
+      universal-user-agent: 2.0.2
+      url-template: 2.0.8
+    dev: true
+    resolution:
+      integrity: sha512-/D1XokSycOE+prxxI2r9cxssiLMqcr+BsEUjdruC67puEEjNJjJoRIkuA1b20jOkX5Ue3Rz99Mu9rTnNmjetUA==
+  /@semantic-release/commit-analyzer/6.1.0:
+    dependencies:
+      conventional-changelog-angular: 5.0.2
+      conventional-commits-filter: 2.0.1
+      conventional-commits-parser: 3.0.1
+      debug: 4.1.0
       import-from: 2.1.0
       lodash: 4.17.11
     dev: true
@@ -838,26 +855,26 @@ packages:
     peerDependencies:
       semantic-release: '>=15.8.0 <16.0.0'
     resolution:
-      integrity: sha512-ENCRn1tm1D08CCBnIPsID8GjboWT6E97s0Lk3XrpAh+IMx615uAU1X2FoXyOGGc6zmqp9Ff4s8KECd/GjMcodQ==
+      integrity: sha512-2lb+t6muGenI86mYGpZYOgITx9L3oZYF697tJoqXeQEk0uw0fm+OkkOuDTBA3Oax9ftoNIrCKv9bwgYvxrbM6w==
   /@semantic-release/error/2.2.0:
     dev: true
     resolution:
       integrity: sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
-  /@semantic-release/github/5.0.5:
+  /@semantic-release/github/5.2.5:
     dependencies:
-      '@octokit/rest': 15.12.0
+      '@octokit/rest': 16.1.0
       '@semantic-release/error': 2.2.0
       aggregate-error: 1.0.0
-      bottleneck: 2.11.0
-      debug: 4.0.1
+      bottleneck: 2.13.2
+      debug: 4.1.0
       dir-glob: 2.0.0
-      fs-extra: 7.0.0
+      fs-extra: 7.0.1
       globby: 8.0.1
       http-proxy-agent: 2.1.0
       https-proxy-agent: 2.2.1
-      issue-parser: 3.0.0
+      issue-parser: 3.0.1
       lodash: 4.17.11
-      mime: 2.3.1
+      mime: 2.4.0
       p-filter: 1.0.0
       p-retry: 2.0.0
       parse-github-url: 1.0.2
@@ -868,20 +885,17 @@ packages:
     peerDependencies:
       semantic-release: '>=15.8.0 <16.0.0'
     resolution:
-      integrity: sha512-Hdt6b8ST2pg6pl151PlcsnTcdsC2UJhA5FdbmunbZG/TVmlnKCZ4WUzpji7YqJtDLjbQTuFm/vhM6atW3XjMWg==
-  /@semantic-release/npm/5.0.4:
+      integrity: sha512-myO00q84CyfyzaEZ4OdA7GOMCQKd+juZd5g2Cloh4jV6CyiMyWflZ629RH99wjAVUiwMKnvX2SQ5XPFvO1+FCw==
+  /@semantic-release/npm/5.1.1:
     dependencies:
       '@semantic-release/error': 2.2.0
       aggregate-error: 1.0.0
-      detect-indent: 5.0.0
-      detect-newline: 2.1.0
       execa: 1.0.0
-      fs-extra: 7.0.0
+      fs-extra: 7.0.1
       lodash: 4.17.11
       nerf-dart: 1.0.0
-      normalize-url: 3.3.0
+      normalize-url: 4.0.0
       npm: 6.4.1
-      parse-json: 4.0.0
       rc: 1.2.8
       read-pkg: 4.0.1
       registry-auth-token: 3.3.2
@@ -891,18 +905,17 @@ packages:
     peerDependencies:
       semantic-release: '>=15.9.0 <16.0.0'
     resolution:
-      integrity: sha512-ExGXP9GnM2hqUIgTnp6sXKB1G0Yh+fuLftmIopq5KHBWj34Wd2YbM/3iLkXXnAP1YZ9YCp7hsAdsR014ctbwHg==
-  /@semantic-release/release-notes-generator/7.0.2:
+      integrity: sha512-5OnV0od1HKp2QjToXxQufvHNG8n+IQlp7h3FjqmZYH7DAHzAGx4NCf/R4p3RhyX5YJEfQl4ZflX9219JVNsuJg==
+  /@semantic-release/release-notes-generator/7.1.4:
     dependencies:
-      conventional-changelog-angular: 5.0.1
-      conventional-changelog-writer: 4.0.0
-      conventional-commits-filter: 2.0.0
-      conventional-commits-parser: 3.0.0
-      debug: 4.0.1
-      get-stream: 4.0.0
-      git-url-parse: 10.0.1
+      conventional-changelog-angular: 5.0.2
+      conventional-changelog-writer: 4.0.2
+      conventional-commits-filter: 2.0.1
+      conventional-commits-parser: 3.0.1
+      debug: 4.1.0
+      get-stream: 4.1.0
       import-from: 2.1.0
-      into-stream: 3.1.0
+      into-stream: 4.0.0
       lodash: 4.17.11
     dev: true
     engines:
@@ -910,15 +923,15 @@ packages:
     peerDependencies:
       semantic-release: '>=15.8.0 <16.0.0'
     resolution:
-      integrity: sha512-fomHrGq/gfZIAQYZk0MLRwfQ8d+DbTcI3kuO1hU2L0fDJYKHZHuPmKnsfVa5KoNdVVPHx878D/ojgyStRqhc9g==
-  /@sindresorhus/is/0.11.0:
+      integrity: sha512-pWPouZujddgb6t61t9iA9G3yIfp3TeQ7bPbV1ixYSeP6L7gI1+Du82fY/OHfEwyifpymLUQW0XnIKgKct5IMMw==
+  /@sindresorhus/is/0.12.0:
     dependencies:
       symbol-observable: 1.2.0
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-i5Zh5+3QARyXtzq3Bd2Lg3aBRFLcgYbNoap3Hyu1uRN8X+D+0JMqqc4uk4XjhNxfVdCnL8WHUA2wxa33QCC50w==
+      integrity: sha512-9ve22cGrAKlSRvi8Vb2JIjzcaaQg79531yQHnF+hi/kOpsSj3Om8AyR1wcHrgl0u7U3vYQ7gmF5erZzOp4+51Q==
   /@sinonjs/commons/1.0.2:
     dependencies:
       type-detect: 4.0.8
@@ -951,14 +964,14 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-WljfOGkmSJe8SUkl+4TPvN2ec0dpUGVyfTBQLoXJUiILs+wBSc4Kvp2N3aAWE4VwwDSLGdmD3/bufS5BgZpVSQ==
-  /JSONStream/1.3.4:
+  /JSONStream/1.3.5:
     dependencies:
       jsonparse: 1.3.1
       through: 2.3.8
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==
+      integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
   /acorn-jsx/5.0.0/acorn@6.0.4:
     dependencies:
       acorn: 6.0.4
@@ -1145,6 +1158,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
+  /array-uniq/2.0.0:
+    dev: true
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg==
   /array-unique/0.3.2:
     dev: true
     engines:
@@ -1236,14 +1255,14 @@ packages:
     dev: true
     resolution:
       integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
-  /before-after-hook/1.1.0:
+  /before-after-hook/1.2.0:
     dev: true
     resolution:
-      integrity: sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==
-  /bottleneck/2.11.0:
+      integrity: sha512-wI3QtdLppHNkmM1VgRVLCrlWCKk/YexlPicYbXPs4eYdd1InrUCTFsx5bX1iUQzzMsoRXXPpM1r+p7JEJJydag==
+  /bottleneck/2.13.2:
     dev: true
     resolution:
-      integrity: sha512-DvKiYR1kG1qRVoLBUtPlmJffktoBZIz3qtdUbINlwzQXDhlhZdF8gWesPjwp05xqr5QZ7wXA2k1w78/COCweTg==
+      integrity: sha512-DVS4Uv7xr4Ql0w9valPBaueLRnEtBepeoevDhWO0LBhyihICJ7RySyzPfyvPswanrXAAbWaF8Zx4QpxmIxHa/g==
   /boxen/1.3.0:
     dependencies:
       ansi-align: 2.0.0
@@ -1252,7 +1271,7 @@ packages:
       cli-boxes: 1.0.0
       string-width: 2.1.1
       term-size: 1.2.0
-      widest-line: 2.0.0
+      widest-line: 2.0.1
     dev: true
     engines:
       node: '>=4'
@@ -1286,15 +1305,15 @@ packages:
     dev: true
     resolution:
       integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
-  /browserslist/4.1.1:
+  /browserslist/4.3.5:
     dependencies:
-      caniuse-lite: 1.0.30000887
-      electron-to-chromium: 1.3.70
-      node-releases: 1.0.0-alpha.11
+      caniuse-lite: 1.0.30000914
+      electron-to-chromium: 1.3.88
+      node-releases: 1.0.5
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==
+      integrity: sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==
   /btoa-lite/1.0.0:
     dev: true
     resolution:
@@ -1325,11 +1344,11 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
-  /cacheable-request/5.0.0:
+  /cacheable-request/5.2.0:
     dependencies:
       clone-response: 1.0.2
-      get-stream: 4.0.0
-      http-cache-semantics: 4.0.0
+      get-stream: 4.1.0
+      http-cache-semantics: 4.0.1
       keyv: 3.1.0
       lowercase-keys: 1.0.1
       normalize-url: 3.3.0
@@ -1338,11 +1357,19 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-gU53XCfodl+GZ37ecX/uLobGE+WvgE2QE3VfhX7sPf04Kc35tNPip3IfCKfqJ2e04HLuHRxFCWgGWttv8OQbfw==
+      integrity: sha512-h1n0vjpFaByTvU6PiyTKk2kx4OnuV1aVUynCUd/FiKl4icpPSceowk3rHczwFEBuZvz+E1EU4KExR0MCPeQfaQ==
   /call-me-maybe/1.0.1:
     dev: true
     resolution:
       integrity: sha1-JtII6onje1y95gJQoV8DHBak1ms=
+  /caller-callsite/2.0.0:
+    dependencies:
+      callsites: 2.0.0
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
   /caller-path/0.1.0:
     dependencies:
       callsites: 0.2.0
@@ -1351,12 +1378,26 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=
+  /caller-path/2.0.0:
+    dependencies:
+      caller-callsite: 2.0.0
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
   /callsites/0.2.0:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
+  /callsites/2.0.0:
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
   /camelcase-keys/4.2.0:
     dependencies:
       camelcase: 4.1.0
@@ -1373,10 +1414,16 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-  /caniuse-lite/1.0.30000887:
+  /camelcase/5.0.0:
+    dev: true
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+  /caniuse-lite/1.0.30000914:
     dev: true
     resolution:
-      integrity: sha512-AHpONWuGFWO8yY9igdXH94tikM6ERS84286r0cAMAXYFtJBk76lhiMhtCxBJNBZsD6hzlvpWZ2AtbVFEkf4JQA==
+      integrity: sha512-qqj0CL1xANgg6iDOybiPTIxtsmAnfIky9mBC35qgWrnK4WwmhqfpmkDYMYgwXJ8LRZ3/2jXlCntulO8mBaAgSg==
   /capture-stack-trace/1.0.1:
     dev: true
     engines:
@@ -1555,7 +1602,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
-      tarball: 'http://registry.npmjs.org/commander/-/commander-2.15.1.tgz'
   /commander/2.17.1:
     dev: true
     optional: true
@@ -1594,7 +1640,7 @@ packages:
   /configstore/3.1.2:
     dependencies:
       dot-prop: 4.2.0
-      graceful-fs: 4.1.11
+      graceful-fs: 4.1.15
       make-dir: 1.3.0
       unique-string: 1.0.0
       write-file-atomic: 2.3.0
@@ -1610,7 +1656,7 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
-  /conventional-changelog-angular/5.0.1:
+  /conventional-changelog-angular/5.0.2:
     dependencies:
       compare-func: 1.3.2
       q: 1.5.1
@@ -1618,26 +1664,26 @@ packages:
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-q4ylJ68fWZDdrFC9z4zKcf97HW6hp7Mo2YlqD4owfXhecFKy/PJCU/1oVFF4TqochchChqmZ0Vb0e0g8/MKNlA==
-  /conventional-changelog-writer/4.0.0:
+      integrity: sha512-yx7m7lVrXmt4nKWQgWZqxSALEiAKZhOAcbxdUaU9575mB0CzXVbgrgpfSnSP7OqWDUTYGD0YVJ0MSRdyOPgAwA==
+  /conventional-changelog-writer/4.0.2:
     dependencies:
       compare-func: 1.3.2
-      conventional-commits-filter: 2.0.0
+      conventional-commits-filter: 2.0.1
       dateformat: 3.0.3
       handlebars: 4.0.12
       json-stringify-safe: 5.0.1
       lodash: 4.17.11
       meow: 4.0.1
-      semver: 5.5.1
+      semver: 5.6.0
       split: 1.0.1
-      through2: 2.0.3
+      through2: 2.0.5
     dev: true
     engines:
       node: '>=6.9.0'
     hasBin: true
     resolution:
-      integrity: sha512-hMZPe0AQ6Bi05epeK/7hz80xxk59nPA5z/b63TOHq2wigM0/akreOc8N4Jam5b9nFgKWX1e9PdPv2ewgW6bcfg==
-  /conventional-commits-filter/2.0.0:
+      integrity: sha512-d8/FQY/fix2xXEBUhOo8u3DCbyEw3UOQgYHxLsPDw+wHUDma/GQGAGsGtoH876WyNs32fViHmTOUrgRKVLvBug==
+  /conventional-commits-filter/2.0.1:
     dependencies:
       is-subset: 0.1.1
       modify-values: 1.0.1
@@ -1645,22 +1691,22 @@ packages:
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-Cfl0j1/NquB/TMVx7Wrmyq7uRM+/rPQbtVVGwzfkhZ6/yH6fcMmP0Q/9044TBZPTNdGzm46vXFXL14wbET0/Mg==
-  /conventional-commits-parser/3.0.0:
+      integrity: sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==
+  /conventional-commits-parser/3.0.1:
     dependencies:
-      JSONStream: 1.3.4
+      JSONStream: 1.3.5
       is-text-path: 1.0.1
       lodash: 4.17.11
       meow: 4.0.1
       split2: 2.2.0
-      through2: 2.0.3
+      through2: 2.0.5
       trim-off-newlines: 1.0.1
     dev: true
     engines:
       node: '>=6.9.0'
     hasBin: true
     resolution:
-      integrity: sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==
+      integrity: sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==
   /convert-source-map/1.6.0:
     dependencies:
       safe-buffer: 5.1.2
@@ -1681,8 +1727,9 @@ packages:
     dev: true
     resolution:
       integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
-  /cosmiconfig/5.0.6:
+  /cosmiconfig/5.0.7:
     dependencies:
+      import-fresh: 2.0.0
       is-directory: 0.3.1
       js-yaml: 3.12.0
       parse-json: 4.0.0
@@ -1690,7 +1737,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==
+      integrity: sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==
   /coveralls/3.0.2:
     dependencies:
       growl: 1.10.5
@@ -1789,12 +1836,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  /debug/4.0.1:
+  /debug/4.1.0:
     dependencies:
       ms: 2.1.1
     dev: true
     resolution:
-      integrity: sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==
+      integrity: sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
   /decamelize-keys/1.1.0:
     dependencies:
       decamelize: 1.2.0
@@ -1810,14 +1857,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
-  /decamelize/2.0.0:
-    dependencies:
-      xregexp: 4.0.0
-    dev: true
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==
   /decode-uri-component/0.2.0:
     dev: true
     engines:
@@ -1854,6 +1893,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  /deepmerge/3.0.0:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-a8z8bkgHsAML+uHLqmMS83HHlpy3PvZOOuiTQqaa3wu8ZVg3h0hqHk6aCsGdOnZV2XMM/FRimNGjUh0KCcmHBw==
   /defer-to-connect/1.0.1:
     dev: true
     resolution:
@@ -1908,18 +1953,6 @@ packages:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-  /detect-indent/5.0.0:
-    dev: true
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-  /detect-newline/2.1.0:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
   /diff/3.5.0:
     dev: true
     engines:
@@ -1991,17 +2024,17 @@ packages:
     dev: true
     resolution:
       integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
-  /electron-to-chromium/1.3.70:
+  /electron-to-chromium/1.3.88:
     dev: true
     resolution:
-      integrity: sha512-WYMjqCnPVS5JA+XvwEnpwucJpVi2+q9cdCFpbhxgWGsCtforFBEkuP9+nCyy/wnU/0SyLcLRIeZct9ayMGcXoQ==
+      integrity: sha512-UPV4NuQMKeUh1S0OWRvwg0PI8ASHN9kBC8yDTk1ROXLC85W5GnhTRu/MZu3Teqx3JjlQYuckuHYXSUSgtb3J+A==
   /end-of-stream/1.4.1:
     dependencies:
       once: 1.4.0
     dev: true
     resolution:
       integrity: sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
-  /env-ci/3.0.0:
+  /env-ci/3.1.2:
     dependencies:
       execa: 1.0.0
       java-properties: 0.2.10
@@ -2009,7 +2042,7 @@ packages:
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-3Xt4Cfjdy9MTTrg/eWTnJNQIrtU1DDV0KyuWOGlrR2oa9dOdzoOMbQBFbfrTiv+GypdiWWIw5HdmtakZO+rzWA==
+      integrity: sha512-qJ+ug5OEHEK6HyjhEB0z2tPJCmdvemQE3WUUYEe7qj7teZIJGjZK9elWB4kxE8qRdVHWl4aBvyVmX0Y5xlMbBw==
   /error-ex/1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -2323,7 +2356,7 @@ packages:
   /execa/1.0.0:
     dependencies:
       cross-spawn: 6.0.5
-      get-stream: 4.0.0
+      get-stream: 4.1.0
       is-stream: 1.1.0
       npm-run-path: 2.0.2
       p-finally: 1.0.0
@@ -2410,19 +2443,19 @@ packages:
     dev: true
     resolution:
       integrity: sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-  /fast-glob/2.2.2:
+  /fast-glob/2.2.4:
     dependencies:
       '@mrmlnc/readdir-enhanced': 2.2.1
-      '@nodelib/fs.stat': 1.1.2
+      '@nodelib/fs.stat': 1.1.3
       glob-parent: 3.1.0
       is-glob: 4.0.0
-      merge2: 1.2.2
+      merge2: 1.2.3
       micromatch: 3.1.10
     dev: true
     engines:
       node: '>=4.0.0'
     resolution:
-      integrity: sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==
+      integrity: sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==
   /fast-json-stable-stringify/2.0.0:
     dev: true
     resolution:
@@ -2498,15 +2531,15 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
-  /find-versions/2.0.0:
+  /find-versions/3.0.0:
     dependencies:
-      array-uniq: 1.0.3
-      semver-regex: 1.0.0
+      array-uniq: 2.0.0
+      semver-regex: 2.0.0
     dev: true
     engines:
-      node: '>=0.10.0'
+      node: '>=6'
     resolution:
-      integrity: sha1-KtkNSQ9oKMGqQCks9wmsMxghDDw=
+      integrity: sha512-IUvtItVFNmTtKoB0PRfbkR0zR9XMG5rWNO3qI1S8L0zdv+v2gqzM0pAunloxqbqAfT8w7bg8n/5gHzTXte8H5A==
   /flat-cache/1.3.4:
     dependencies:
       circular-json: 0.3.3
@@ -2563,6 +2596,16 @@ packages:
       node: '>=6 <7 || >=8'
     resolution:
       integrity: sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==
+  /fs-extra/7.0.1:
+    dependencies:
+      graceful-fs: 4.1.15
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+    dev: true
+    engines:
+      node: '>=6 <7 || >=8'
+    resolution:
+      integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   /fs.realpath/1.0.0:
     dev: true
     resolution:
@@ -2595,14 +2638,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
-  /get-stream/4.0.0:
+  /get-stream/4.1.0:
     dependencies:
       pump: 3.0.0
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-FneLKMENeOR7wOK0/ZXCh+lwqtnPwkeunJjRN28LPqzGvNAhYvrTAhXv6xDm4vsJ0M7lcRbIYHQudKsSy2RtSQ==
+      integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
   /get-value/2.0.6:
     dev: true
     engines:
@@ -2621,24 +2664,11 @@ packages:
       spawn-error-forwarder: 1.0.0
       split2: 1.0.0
       stream-combiner2: 1.1.1
-      through2: 2.0.3
+      through2: 2.0.5
       traverse: 0.6.6
     dev: true
     resolution:
       integrity: sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=
-  /git-up/2.0.10:
-    dependencies:
-      is-ssh: 1.3.0
-      parse-url: 1.3.11
-    dev: true
-    resolution:
-      integrity: sha512-2v4UN3qV2RGypD9QpmUjpk+4+RlYpW8GFuiZqQnKmvei08HsFPd0RfbDvEhnE4wBvnYs8ORVtYpOFuuCEmBVBw==
-  /git-url-parse/10.0.1:
-    dependencies:
-      git-up: 2.0.10
-    dev: true
-    resolution:
-      integrity: sha512-Tq2u8UPXc/FawC/dO8bvh8jcck0Lkor5OhuZvmVSeyJGRucDBfw9y2zy/GNCx28lMYh1N12IzPwDexjUNFyAeg==
   /glob-parent/3.1.0:
     dependencies:
       is-glob: 3.1.0
@@ -2696,7 +2726,7 @@ packages:
     dependencies:
       array-union: 1.0.2
       dir-glob: 2.0.0
-      fast-glob: 2.2.2
+      fast-glob: 2.2.4
       glob: 7.1.3
       ignore: 3.3.10
       pify: 3.0.0
@@ -2724,24 +2754,24 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
-      tarball: 'http://registry.npmjs.org/got/-/got-6.7.1.tgz'
-  /got/9.2.2:
+  /got/9.3.2:
     dependencies:
-      '@sindresorhus/is': 0.11.0
+      '@sindresorhus/is': 0.12.0
       '@szmarczak/http-timer': 1.1.1
-      cacheable-request: 5.0.0
+      cacheable-request: 5.2.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
-      get-stream: 4.0.0
+      get-stream: 4.1.0
+      lowercase-keys: 1.0.1
       mimic-response: 1.0.1
-      p-cancelable: 0.5.1
+      p-cancelable: 1.0.0
       to-readable-stream: 1.0.0
       url-parse-lax: 3.0.0
     dev: true
     engines:
       node: '>=8.6'
     resolution:
-      integrity: sha512-XLXmtO1QxLuzj6t4JBClWD1NI/bMvsR9utYl0yyPg49eUJjqU7HaQhPDvSVGwYoSbAqsRfe5aNZXHl1Zctzwmw==
+      integrity: sha512-OyKOUg71IKvwb8Uj0KP6EN3+qVVvXmYsFznU1fnwUnKtDbZnwSlAi7muNlu4HhBfN9dImtlgg9e7H0g5qVdaeQ==
   /graceful-fs/4.1.11:
     dev: true
     engines:
@@ -2860,20 +2890,20 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=
-  /hook-std/1.1.0:
+  /hook-std/1.2.0:
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-aIyBZbZl3NS8XoSwIDQ+ZaiBuPOhhPWoBFA3QX0Q8hOMO8Tx4xGRTDnn/nl/LAtZWdieXzFC9ohAtTSnWrlHCQ==
+      integrity: sha512-yntre2dbOAjgQ5yoRykyON0D9T96BfshR8IuiL/r3celeHD8I/76w4qo8m3z99houR4Z678jakV3uXrQdSvW/w==
   /hosted-git-info/2.7.1:
     dev: true
     resolution:
       integrity: sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
-  /http-cache-semantics/4.0.0:
+  /http-cache-semantics/4.0.1:
     dev: true
     resolution:
-      integrity: sha512-NtexGRtaV5z3ZUX78W9UDTOJPBdpqms6RmwQXmOhHws7CuQK3cqIoQtnmeqi1VvVD6u6eMMRL0sKE9BCZXTDWQ==
+      integrity: sha512-OO/9K7uFN30qwAKvslzmCTbimZ/uRjtdN5S50vvWLwUKqFuZj0n96XyCzF5tHRHEO/Q4JYC01hv41gkX06gmHA==
   /http-proxy-agent/2.1.0:
     dependencies:
       agent-base: 4.2.1
@@ -2897,7 +2927,7 @@ packages:
   /https-proxy-agent/2.2.1:
     dependencies:
       agent-base: 4.2.1
-      debug: 3.2.5
+      debug: 3.2.6
     dev: true
     engines:
       node: '>= 4.5.0'
@@ -2921,6 +2951,15 @@ packages:
       node: '>= 4'
     resolution:
       integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+  /import-fresh/2.0.0:
+    dependencies:
+      caller-path: 2.0.0
+      resolve-from: 3.0.0
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
   /import-from/2.1.0:
     dependencies:
       resolve-from: 3.0.0
@@ -3003,15 +3042,15 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==
-  /into-stream/3.1.0:
+  /into-stream/4.0.0:
     dependencies:
       from2: 2.3.0
-      p-is-promise: 1.1.0
+      p-is-promise: 2.0.0
     dev: true
     engines:
-      node: '>=4'
+      node: '>=6'
     resolution:
-      integrity: sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=
+      integrity: sha512-i29KNyE5r0Y/UQzcQ0IbZO1MYJ53Jn0EcFRZPj5FzWKYH17kDFEOwuA+3jroymOI06SW1dEDnly9A1CAreC5dg==
   /invariant/2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -3202,7 +3241,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
-      tarball: 'http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz'
   /is-path-inside/1.0.1:
     dependencies:
       path-is-inside: 1.0.2
@@ -3253,12 +3291,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
-  /is-ssh/1.3.0:
-    dependencies:
-      protocols: 1.4.6
-    dev: true
-    resolution:
-      integrity: sha1-6+oRaaJhTaOSpjdANmw84EnY3/Y=
   /is-stream/1.1.0:
     dev: true
     engines:
@@ -3279,7 +3311,7 @@ packages:
       integrity: sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
   /is-text-path/1.0.1:
     dependencies:
-      text-extensions: 1.8.0
+      text-extensions: 1.9.0
     dev: true
     engines:
       node: '>=0.10.0'
@@ -3325,7 +3357,7 @@ packages:
     dev: true
     resolution:
       integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
-  /issue-parser/3.0.0:
+  /issue-parser/3.0.1:
     dependencies:
       lodash.capitalize: 4.2.1
       lodash.escaperegexp: 4.1.2
@@ -3336,7 +3368,7 @@ packages:
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-VWIhBdy0eOhlvpxOOMecBCHMpjx7lWVZcYpSzjD4dSdxptzI9TBR/cQEh057HL8+7jQKTLs+uCtezY/9VoveCA==
+      integrity: sha512-5wdT3EE8Kq38x/hJD8QZCJ9scGoOZ5QnzwXyClkviSWTS+xOCE6hJ0qco3H5n5jCsFqpbofZCcMWqlXJzF72VQ==
   /istanbul-lib-coverage/2.0.1:
     dev: true
     engines:
@@ -3363,12 +3395,12 @@ packages:
       node: '>= 0.6.0'
     resolution:
       integrity: sha512-CpKJh9VRNhS+XqZtg1UMejETGEiqwCGDC/uwPEEQwc2nfdbSm73SIE29TplG2gLYuBOOTNDqxzG6A9NtEPLt0w==
-  /js-levenshtein/1.1.3:
+  /js-levenshtein/1.1.4:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-/812MXr9RBtMObviZ8gQBhHO8MOrGj8HlEE+4ccMTElNA/6I3u39u+bhny55Lk921yn44nSZFy9naNLElL5wgQ==
+      integrity: sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow==
   /js-tokens/3.0.2:
     dev: true
     resolution:
@@ -3401,6 +3433,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=
+  /jsesc/2.5.2:
+    dev: true
+    engines:
+      node: '>=4'
+    hasBin: true
+    resolution:
+      integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
   /json-buffer/3.0.0:
     dev: true
     resolution:
@@ -3425,11 +3464,15 @@ packages:
     dev: true
     resolution:
       integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-  /json5/0.5.1:
+  /json5/2.1.0:
+    dependencies:
+      minimist: 1.2.0
     dev: true
+    engines:
+      node: '>=6'
     hasBin: true
     resolution:
-      integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
+      integrity: sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   /jsonfile/4.0.0:
     dev: true
     optionalDependencies:
@@ -3600,10 +3643,22 @@ packages:
     dev: true
     resolution:
       integrity: sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+  /lodash.pick/4.4.0:
+    dev: true
+    resolution:
+      integrity: sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+  /lodash.set/4.3.2:
+    dev: true
+    resolution:
+      integrity: sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
   /lodash.toarray/4.4.0:
     dev: true
     resolution:
       integrity: sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
+  /lodash.uniq/4.5.0:
+    dev: true
+    resolution:
+      integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
   /lodash.uniqby/4.7.0:
     dev: true
     resolution:
@@ -3663,12 +3718,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
-  /macos-release/1.1.0:
+  /macos-release/2.0.0:
     dev: true
     engines:
-      node: '>=0.10.0'
+      node: '>=6'
     resolution:
-      integrity: sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==
+      integrity: sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==
   /make-dir/1.3.0:
     dependencies:
       pify: 3.0.0
@@ -3677,14 +3732,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
-  /map-age-cleaner/0.1.2:
+  /map-age-cleaner/0.1.3:
     dependencies:
       p-defer: 1.0.0
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==
+      integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
   /map-cache/0.2.2:
     dev: true
     engines:
@@ -3711,13 +3766,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
-  /marked-terminal/3.1.1/marked@0.5.0:
+  /marked-terminal/3.1.1/marked@0.5.2:
     dependencies:
       cardinal: 2.1.1
       chalk: 2.4.1
       cli-table: 0.3.1
       lodash.assign: 4.2.0
-      marked: 0.5.0
+      marked: 0.5.2
       node-emoji: 1.8.1
     dev: true
     id: registry.npmjs.org/marked-terminal/3.1.1
@@ -3725,13 +3780,13 @@ packages:
       marked: ^0.4.0 || ^0.5.0
     resolution:
       integrity: sha512-7UBFww1rdx0w9HehLMCVYa8/AxXaiDigDfMsJcj82/wgLQG9cj+oiMAVlJpeWD57VFJY2OYY+bKeEVIjIlxi+w==
-  /marked/0.5.0:
+  /marked/0.5.2:
     dev: true
     engines:
       node: '>=0.10.0'
     hasBin: true
     resolution:
-      integrity: sha512-UhjmkCWKu1SS/BIePL2a59BMJ7V42EYtTfksodPRXzPEGEph3Inp5dylseqt+KbU9Jglsx8xcMKmlumfJMBXAA==
+      integrity: sha512-fdZvBa7/vSQIZCi4uuwo2N3q+7jJURpMVCcbaX0S1Mg65WZ5ilXvC67MviJAsdjqqgD+CEq4RKo5AYGgINkVAA==
   /mem/1.1.0:
     dependencies:
       mimic-fn: 1.2.0
@@ -3742,7 +3797,7 @@ packages:
       integrity: sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   /mem/4.0.0:
     dependencies:
-      map-age-cleaner: 0.1.2
+      map-age-cleaner: 0.1.3
       mimic-fn: 1.2.0
       p-is-promise: 1.1.0
     dev: true
@@ -3766,12 +3821,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==
-  /merge2/1.2.2:
+  /merge2/1.2.3:
     dev: true
     engines:
       node: '>= 4.5.0'
     resolution:
-      integrity: sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==
+      integrity: sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
   /micromatch/3.1.10:
     dependencies:
       arr-diff: 4.0.0
@@ -3806,13 +3861,13 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
-  /mime/2.3.1:
+  /mime/2.4.0:
     dev: true
     engines:
       node: '>=4.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==
+      integrity: sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
   /mimic-fn/1.2.0:
     dev: true
     engines:
@@ -3844,7 +3899,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
-      tarball: 'http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz'
   /minimist/0.0.8:
     dev: true
     resolution:
@@ -3968,24 +4022,24 @@ packages:
     dev: true
     resolution:
       integrity: sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==
-  /node-fetch/2.2.0:
+  /node-fetch/2.3.0:
     dev: true
     engines:
       node: 4.x || >=6.0.0
     resolution:
-      integrity: sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==
+      integrity: sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
   /node-modules-regexp/1.0.0:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
-  /node-releases/1.0.0-alpha.11:
+  /node-releases/1.0.5:
     dependencies:
-      semver: 5.5.1
+      semver: 5.6.0
     dev: true
     resolution:
-      integrity: sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==
+      integrity: sha512-Ky7q0BO1BBkG/rQz6PkEZ59rwo+aSfhczHP1wwq8IowoVdN/FpiP7qp0XW0P2+BVCWe5fQUBozdbVd54q1RbCQ==
   /normalize-package-data/2.4.0:
     dependencies:
       hosted-git-info: 2.7.1
@@ -4001,6 +4055,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+  /normalize-url/4.0.0:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-OrtNzJOeI9+UaF8KfvPoqh8ZVjLiun+fggtLzrpPsmdOU01eIp3vYXDfeFv4KwqJxcmmrW/ubNCN+9iIQRVtfw==
   /npm-run-path/2.0.2:
     dependencies:
       path-key: 2.0.1
@@ -4215,6 +4275,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
+  /octokit-pagination-methods/1.1.0:
+    dev: true
+    resolution:
+      integrity: sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -4269,27 +4333,27 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==
-  /os-name/2.0.1:
+  /os-name/3.0.0:
     dependencies:
-      macos-release: 1.1.0
-      win-release: 1.1.1
+      macos-release: 2.0.0
+      windows-release: 3.1.0
     dev: true
     engines:
-      node: '>=0.10.0'
+      node: '>=6'
     resolution:
-      integrity: sha1-uaOGNhwXrjohc27wWZQFyajF3F4=
+      integrity: sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==
   /os-tmpdir/1.0.2:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-  /p-cancelable/0.5.1:
+  /p-cancelable/1.0.0:
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-vkOBXQgQb03QTOoMeeB5/uS2W3iafXzQLaIh7ChHjEb8DDT06sWJizhdOACL1Sittl5dFqsyumJ4rD1WUF8Isw==
+      integrity: sha512-USgPoaC6tkTGlS831CxsVdmZmyb8tR1D+hStI84MyckLOzfJlYQUweomrwE3D8T7u5u5GVuW064LT501wHTYYA==
   /p-defer/1.0.0:
     dev: true
     engines:
@@ -4316,7 +4380,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
-      tarball: 'http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz'
+  /p-is-promise/2.0.0:
+    dev: true
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==
   /p-limit/1.3.0:
     dependencies:
       p-try: 1.0.0
@@ -4386,7 +4455,7 @@ packages:
       got: 6.7.1
       registry-auth-token: 3.3.2
       registry-url: 3.1.0
-      semver: 5.5.1
+      semver: 5.6.0
     dev: true
     engines:
       node: '>=4'
@@ -4422,13 +4491,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  /parse-url/1.3.11:
-    dependencies:
-      is-ssh: 1.3.0
-      protocols: 1.4.6
-    dev: true
-    resolution:
-      integrity: sha1-V8FUKKuKiSsfQ4aWRccR0OFEtVQ=
   /pascalcase/0.1.1:
     dev: true
     engines:
@@ -4637,10 +4699,6 @@ packages:
       '0': node >= 0.8.1
     resolution:
       integrity: sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=
-  /protocols/1.4.6:
-    dev: true
-    resolution:
-      integrity: sha1-+LsmPqG1/Xp2BNJri+Ob13Z4v4o=
   /pseudomap/1.0.2:
     dev: true
     resolution:
@@ -4764,7 +4822,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
-      tarball: 'http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz'
   /redent/2.0.0:
     dependencies:
       indent-string: 3.2.0
@@ -5020,55 +5077,54 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-  /semantic-release/15.9.16:
+  /semantic-release/15.12.4:
     dependencies:
-      '@semantic-release/commit-analyzer': 6.0.1
+      '@semantic-release/commit-analyzer': 6.1.0
       '@semantic-release/error': 2.2.0
-      '@semantic-release/github': 5.0.5
-      '@semantic-release/npm': 5.0.4
-      '@semantic-release/release-notes-generator': 7.0.2
+      '@semantic-release/github': 5.2.5
+      '@semantic-release/npm': 5.1.1
+      '@semantic-release/release-notes-generator': 7.1.4
       aggregate-error: 1.0.0
-      cosmiconfig: 5.0.6
-      debug: 4.0.1
-      env-ci: 3.0.0
+      cosmiconfig: 5.0.7
+      debug: 4.1.0
+      env-ci: 3.1.2
       execa: 1.0.0
       figures: 2.0.0
-      find-versions: 2.0.0
-      get-stream: 4.0.0
+      find-versions: 3.0.0
+      get-stream: 4.1.0
       git-log-parser: 1.2.0
-      git-url-parse: 10.0.1
-      hook-std: 1.1.0
+      hook-std: 1.2.0
       hosted-git-info: 2.7.1
       lodash: 4.17.11
-      marked: 0.5.0
-      marked-terminal: /marked-terminal/3.1.1/marked@0.5.0
+      marked: 0.5.2
+      marked-terminal: /marked-terminal/3.1.1/marked@0.5.2
       p-locate: 3.0.0
       p-reduce: 1.0.0
       read-pkg-up: 4.0.0
       resolve-from: 4.0.0
-      semver: 5.5.1
+      semver: 5.6.0
       signale: 1.3.0
-      yargs: 12.0.2
+      yargs: 12.0.5
     dev: true
     engines:
       node: '>=8.3'
     hasBin: true
     resolution:
-      integrity: sha512-5RWqMFwDBXzIaNGUdnJxI4aCd4DtKtdc+5ZNjNWXABEmkimZVuuzZhMaTVNhHYfSuVUqWG9GuATEKhjlVoTzfQ==
+      integrity: sha512-po30Te9E26v3Qb/G9pXFO6lCTFO07zvliqH00vmfuCoAjl1Wpg9SKb9dXVFM7BTdg5Fr/KqbdOsqHkT7kR4FeQ==
   /semver-diff/2.1.0:
     dependencies:
-      semver: 5.5.1
+      semver: 5.6.0
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=
-  /semver-regex/1.0.0:
+  /semver-regex/2.0.0:
     dev: true
     engines:
-      node: '>=0.10.0'
+      node: '>=6'
     resolution:
-      integrity: sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=
+      integrity: sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
   /semver/5.5.1:
     dev: true
     hasBin: true
@@ -5269,13 +5325,13 @@ packages:
       integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   /split2/1.0.0:
     dependencies:
-      through2: 2.0.3
+      through2: 2.0.5
     dev: true
     resolution:
       integrity: sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=
   /split2/2.2.0:
     dependencies:
-      through2: 2.0.3
+      through2: 2.0.5
     dev: true
     resolution:
       integrity: sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
@@ -5466,12 +5522,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-45mpgiV6J22uQou5KEXLcb3CbRk=
-  /text-extensions/1.8.0:
+  /text-extensions/1.9.0:
     dev: true
     engines:
       node: '>=0.10'
     resolution:
-      integrity: sha512-mVzjRxuWnDKs/qH1rbOJEVHLlSX9kty9lpi7lMvLgU9S74mQ8/Ozg9UPcKxShh0qG2NZ+NyPOPpcZU4C1Eld9A==
+      integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
   /text-table/0.2.0:
     dev: true
     resolution:
@@ -5480,13 +5536,13 @@ packages:
     dev: true
     resolution:
       integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-  /through2/2.0.3:
+  /through2/2.0.5:
     dependencies:
       readable-stream: 2.3.6
       xtend: 4.0.1
     dev: true
     resolution:
-      integrity: sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=
+      integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
   /timed-out/4.0.1:
     dev: true
     engines:
@@ -5554,26 +5610,26 @@ packages:
     dev: true
     resolution:
       integrity: sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
-  /travis-deploy-once/5.0.8:
+  /travis-deploy-once/5.0.9:
     dependencies:
-      '@babel/core': 7.1.0
+      '@babel/core': 7.2.0
       '@babel/polyfill': 7.0.0
-      '@babel/preset-env': /@babel/preset-env/7.1.0/@babel!core@7.1.0
-      '@babel/register': /@babel/register/7.0.0/@babel!core@7.1.0
+      '@babel/preset-env': /@babel/preset-env/7.2.0/@babel!core@7.2.0
+      '@babel/register': /@babel/register/7.0.0/@babel!core@7.2.0
       chalk: 2.4.1
       execa: 1.0.0
-      got: 9.2.2
+      got: 9.3.2
       p-retry: 2.0.0
-      semver: 5.5.1
+      semver: 5.6.0
       update-notifier: 2.5.0
       url-join: 4.0.0
-      yargs: 12.0.2
+      yargs: 12.0.5
     dev: true
     engines:
       node: '>=6'
     hasBin: true
     resolution:
-      integrity: sha512-o6ctY5XZ49/FuHw+7Z66woBqjLCJDiRJsZzZTHSlpCqwl4raDX6Io1bZCbfwaHs4FjKDuYr9ZfWy3phTUx3haw==
+      integrity: sha512-cyHFErzq0HTEGY29RAq1clqFdt/IkCrlcOmyM1cGoGnEyukrrFi1fpy6JH3Mlf+88XsFwvluqKVWzj2bdz3k8A==
   /trim-newlines/2.0.0:
     dev: true
     engines:
@@ -5681,12 +5737,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
-  /universal-user-agent/2.0.1:
+  /universal-user-agent/2.0.2:
     dependencies:
-      os-name: 2.0.1
+      os-name: 3.0.0
     dev: true
     resolution:
-      integrity: sha512-vz+heWVydO0iyYAa65VHD7WZkYzhl7BeNVy4i54p4TF8OMiLSXdbuQe4hm+fmWAsL+rVibaQHXfhvkw3c1Ws2w==
+      integrity: sha512-nOwvHWLH3dBazyuzbECPA5uVFNd7AlgviXRHgR4yf48QqitIvpdncRrxMbZNMpPPEfgz30I9ubd1XmiJiqsTrg==
   /universalify/0.1.2:
     dev: true
     engines:
@@ -5802,22 +5858,22 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  /widest-line/2.0.0:
+  /widest-line/2.0.1:
     dependencies:
       string-width: 2.1.1
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=
-  /win-release/1.1.1:
+      integrity: sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
+  /windows-release/3.1.0:
     dependencies:
-      semver: 5.5.1
+      execa: 0.10.0
     dev: true
     engines:
-      node: '>=0.10.0'
+      node: '>=6'
     resolution:
-      integrity: sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=
+      integrity: sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==
   /wordwrap/0.0.3:
     dev: true
     engines:
@@ -5843,7 +5899,7 @@ packages:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
   /write-file-atomic/2.3.0:
     dependencies:
-      graceful-fs: 4.1.11
+      graceful-fs: 4.1.15
       imurmurhash: 0.1.4
       signal-exit: 3.0.2
     dev: true
@@ -5863,10 +5919,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
-  /xregexp/4.0.0:
-    dev: true
-    resolution:
-      integrity: sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==
   /xtend/4.0.1:
     dev: true
     engines:
@@ -5885,12 +5937,13 @@ packages:
     dev: true
     resolution:
       integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-  /yargs-parser/10.1.0:
+  /yargs-parser/11.1.1:
     dependencies:
-      camelcase: 4.1.0
+      camelcase: 5.0.0
+      decamelize: 1.2.0
     dev: true
     resolution:
-      integrity: sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+      integrity: sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
   /yargs-parser/8.1.0:
     dependencies:
       camelcase: 4.1.0
@@ -5914,10 +5967,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==
-  /yargs/12.0.2:
+  /yargs/12.0.5:
     dependencies:
       cliui: 4.1.0
-      decamelize: 2.0.0
+      decamelize: 1.2.0
       find-up: 3.0.0
       get-caller-file: 1.0.3
       os-locale: 3.0.1
@@ -5927,10 +5980,10 @@ packages:
       string-width: 2.1.1
       which-module: 2.0.0
       y18n: 4.0.0
-      yargs-parser: 10.1.0
+      yargs-parser: 11.1.1
     dev: true
     resolution:
-      integrity: sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==
+      integrity: sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
 registry: 'https://registry.npmjs.org/'
 shrinkwrapMinorVersion: 9
 shrinkwrapVersion: 3
@@ -5945,7 +5998,7 @@ specifiers:
   mocha: ^5.2.0
   nock: ^9.6.1
   nyc: ^12.0.2
-  semantic-release: ^15.9.9
+  semantic-release: ^15.12.0
   sinon: ^6.1.5
   standard: ^12.0.1
-  travis-deploy-once: ^5.0.2
+  travis-deploy-once: ^5.0.9

--- a/test/test.js
+++ b/test/test.js
@@ -241,8 +241,46 @@ describe('simple-thumbnail creates thumbnails for videos', () => {
     })
   })
 
-  describe('write-stream output', () => {
+  describe('stream output', () => {
     it('writes to a file via a write-stream', async () => {
+      const outPath = absolutePath('./out/write.png')
+      const filePath = absolutePath('./data/bunny.mp4')
+      const writeStream = fs.createWriteStream(outPath)
+
+      await genThumbnail(filePath, writeStream, tinySize)
+    })
+
+    it('returns a read-stream on null output', function (done) {
+      const outPath = absolutePath('./out/read.png')
+      const filePath = absolutePath('./data/bunny.mp4')
+      const writeStream = fs.createWriteStream(outPath)
+
+      genThumbnail(filePath, null, tinySize)
+        .then((readStream) => {
+          readStream.pipe(writeStream)
+
+          writeStream.on('finish', done)
+          writeStream.on('error', done)
+        })
+    })
+
+    it('handles input read stream on null output', function (done) {
+      const outPath = absolutePath('./out/readstream.png')
+      const inputStream = fs.createReadStream(absolutePath('./data/bunny.mp4'))
+      const writeStream = fs.createWriteStream(outPath)
+
+      genThumbnail(inputStream, null, tinySize)
+        .then((readStream) => {
+          readStream.pipe(writeStream)
+
+          writeStream.on('finish', done)
+          writeStream.on('error', done)
+        })
+    })
+  })
+
+  describe('read-stream output', () => {
+    it('returns a read-stream on null output', async () => {
       const outPath = absolutePath('./out/write.png')
       const filePath = absolutePath('./data/bunny.mp4')
       const writeStream = fs.createWriteStream(outPath)

--- a/test/test.js
+++ b/test/test.js
@@ -241,6 +241,16 @@ describe('simple-thumbnail creates thumbnails for videos', () => {
     })
   })
 
+  describe('write-stream output', () => {
+    it('writes to a file via a write-stream', async () => {
+      const outPath = absolutePath('./out/write.png')
+      const filePath = absolutePath('./data/bunny.mp4')
+      const writeStream = fs.createWriteStream(outPath)
+
+      await genThumbnail(filePath, writeStream, tinySize)
+    })
+  })
+
   describe('external error handling', () => {
     it('throws an error if stderr fires an error event', async () => {
 


### PR DESCRIPTION
<!--
  While filling all of these sections out is optional, it's highly recommended
  that you fill out context and objective; it doesn't need to be extremely detailed
-->

## Context

There are situations where users may not want to save the thumbnails to disk, instead, they may want to pipe the image stream to a write stream (eg. S3, HTTP response, etc.).

Users will now be able to pass `Stream.Writable` as the output argument, eg.

```js
// "app" refers to an Express application
app.get('/give/me/a/thumbnail/please', (req, res) => {
  // cool, huh?
  genThumbnail('path/to/video.webm', res, '150x100')
    .then(() => console.log('Done! :D'))
    .catch(() => console.error('Error! D:'))
})
```

## Objective

* Allow users to path a writable stream instead of a file path

## References

* https://github.com/ScottyFillups/simple-thumbnail/issues/28

## Lessons learned

* `pnpm` does not play nicely with ALE and Standard :sob: 
