### PR TITLE
Reject promise on invalid seek

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,10 @@ function ffmpegExecute (path, args, rstream, wstream) {
         const err = new Error(`ffmpeg exited ${code}\nffmpeg stderr:\n\n${stderr}`)
         reject(err)
       }
+      if (stderr.includes('nothing was encoded')) {
+        const err = new Error(`ffmpeg failed to encode file\nffmpeg stderr:\n\n${stderr}`)
+        reject(err)
+      }
     })
     ffmpeg.on('close', resolve)
   })

--- a/test/test.js
+++ b/test/test.js
@@ -165,7 +165,7 @@ test('operates when ffmpeg path specified via env var', async t => {
   process.env.FFMPEG_PATH = ''
 })
 
-test.only('throws error when seek is outside range', async t => {
+test('throws error when seek is outside range', async t => {
   const input = absPath('./data/bunny.webm')
   const output = absPath('./out/doesnotmatter.png')
 

--- a/test/test.js
+++ b/test/test.js
@@ -165,6 +165,19 @@ test('operates when ffmpeg path specified via env var', async t => {
   process.env.FFMPEG_PATH = ''
 })
 
+test.only('throws error when seek is outside range', async t => {
+  const input = absPath('./data/bunny.webm')
+  const output = absPath('./out/doesnotmatter.png')
+
+  try {
+    await genThumbnail(input, output, '50x?', { seek: '00:05:00' })
+    t.fail()
+  } catch (err) {
+    console.log(err)
+    t.pass()
+  }
+})
+
 // Currently doesn't save in out folder since there's some weird race condition
 test('writes to a file via a write-stream', imageCreationMacro, {
   output: fs.createWriteStream(absPath('./write.png'))


### PR DESCRIPTION
<!--
  Feel free to deviate from the template, but please include
  links to related issues or PRs, if applicable.
-->

## Context

When an invalid seek is provided, `simple-thumbnail` does not throw an error; it fails silently

## Objective

* Ensure an error is thrown if `ffmpeg` fails to encode the medium

## References

* Issue: https://github.com/ScottyFillups/simple-thumbnail/issues/56
