### PR TITLE
fix: wrap path with quotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function buildArgs (input, output, { width, height, percentage }, seek) {
  * @returns {Promise}  Promise that resolves once thumbnail is generated
  */
 function ffmpegExecute (path, args, rstream, wstream) {
-  const ffmpeg = spawn(path, args, { shell: true })
+  const ffmpeg = spawn(`"${path}"`, args, { shell: true })
   let stderr = ''
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
<!--
  Feel free to deviate from the template, but please include
  links to related issues or PRs, if applicable.
-->

## Context

`simple-thumbnail` does not work if the path to the FFMPEG binary contains spaces.

## References

https://github.com/ScottyFillups/simple-thumbnail/issues/64